### PR TITLE
URL fragment-based routing via pager.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import ko from "knockout";
+import pager from "pagerjs";
 
 import documentselection from "./vm/documentselection";
 import user from "./vm/user";
@@ -7,28 +8,27 @@ import config from "./config";
 
 export default class App {
   constructor() {
-    this.visible = 'documentselection';
-
-    ko.track(this);
-  }
-
-  show(name) {
-    this.visible = name;
+    ko.defineProperty(this, 'activePageName', () => {
+        let activePage = pager.page.currentChildPage()();
+        return activePage ? activePage.getId() : null;
+    });
   }
 
   openLecture(lecture) {
     this.documentlist.load(lecture.name);
-    this.visible = 'documentselection';
+    pager.navigate('#documentselection');
   }
 
-  // causes actual login and moves away to selection view
-  login() {
-    user.login(() => this.show('documentselection'));
+  ensureAuthenticated(page, route, callback) {
+    if (user.isAuthenticated)
+      callback();
+    else
+      pager.navigate(pager.page.path({ path: 'login', params: { successRoute: route.join('/') } }));
   }
 
   // causes actual logout and moves away to selection view
   logout() {
-    user.logout(() => this.show('documentselection'));
+    user.logout(() => pager.navigate('#'));
   }
 
   get user() { return user; }

--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import "jquery.cookie";
 import ko from "knockout";
 import "knockout-es5/src/knockout-es5";
+import pager from "pagerjs";
 
 import "./lib";
 import "./ko/bootstrap";
@@ -49,9 +50,11 @@ $(document).ready(() => {
     template: fs.readFileSync('views/correction.html', 'utf8')
   });
   ko.components.register('login', {
-    viewModel: { instance: require('./vm/user') },
+    viewModel: require('./vm/login'),
     template: fs.readFileSync('views/login.html', 'utf8')
   });
 
+  pager.extendWithPage(app);
   ko.applyBindings(app);
+  pager.start();
 });

--- a/js/vm/documentlist.js
+++ b/js/vm/documentlist.js
@@ -16,8 +16,11 @@ export default class DocumentList {
 
   load(name) {
     this.lecture = name;
-    config.getJSON('/data/lectures/' + encodeURIComponent(name) + '/documents')
-      .done(data => this.documents = data.map(d => new Document(d)));
+    if (name)
+      config.getJSON('/data/lectures/' + encodeURIComponent(name) + '/documents')
+        .done(data => this.documents = data.map(d => new Document(d)));
+    else
+      this.documents = [];
   }
 
   filtered() {

--- a/js/vm/documentselection.js
+++ b/js/vm/documentselection.js
@@ -1,4 +1,5 @@
 import ko from "knockout";
+import pager from "pagerjs";
 
 import config from "../config";
 import user from "./user";
@@ -13,7 +14,12 @@ class DocumentSelection {
     this.documentlist = new DocumentList();
     this.lecturelist = new LectureList();
     this.rangeSelect = new RangeSelect(this.cart);
+
     ko.track(this);
+
+    ko.getObservable(this.documentlist, 'lecture').subscribe(name =>
+        pager.navigate('documentselection' + (name ? '/' + encodeURIComponent(name) : ''))
+    );
   }
 
   get config() { return config; }

--- a/js/vm/login.js
+++ b/js/vm/login.js
@@ -1,0 +1,29 @@
+import ko from "knockout";
+import pager from "pagerjs";
+import $ from "jquery";
+
+import user from "./user";
+
+export default class Login {
+  constructor(params) {
+    this.password = '';
+    this.rememberMe = true;
+    this.errorThrown = '';
+    this.successRoute = params.successRoute;
+
+    ko.track(this);
+  }
+
+  login() {
+    // Hack to force KO to fetch input values. This should fix firefox' filled-in
+    // credentials not actually being sent.
+    $('#login-form').find('input').change();
+
+    user.login(this.password, this.rememberMe,
+        msg => this.errorThrown = msg,
+        () => pager.navigate(this.successRoute)
+    );
+  }
+
+  get user() { return user; }
+}

--- a/js/vm/user.js
+++ b/js/vm/user.js
@@ -8,9 +8,6 @@ class User {
     this.username = '';
     this.firstName = '';
     this.lastName = '';
-    this.password = '';
-    this.rememberMe = true;
-    this.errorThrown = '';
     this.isAuthenticated = false;
 
     this.onAuthUpdate();
@@ -33,19 +30,10 @@ class User {
     });
   }
 
-  login(success) {
-    // Hack to force KO to fetch input values. This should fix firefox' filled-in
-    // credentials not actually being sent.
-    $('#login-form').find('input').change();
-
-    config.post('/data/login', {user: this.username, password: this.password, rememberMe: this.rememberMe}, {
-      error: (xhr, _, errorThrown) => {
-        this.errorThrown = xhr.status + ': ' + xhr.responseText;
-        this.onAuthUpdate();
-      }
+  login(password, rememberMe, error, success) {
+    config.post('/data/login', {user: this.username, password: password, rememberMe: rememberMe}, {
+      error: (xhr, _, errorThrown) => error(xhr.status + ': ' + xhr.responseText)
     }).done(() => {
-      this.password = '';
-      this.errorThrown = '';
       if (!$.cookie('sessionid')) {
         $.cookie('sessionid', true);
       }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,16 @@
     "type": "git",
     "url": "https://github.com/fsmi/odie-client.git"
   },
-  "browser": {
-    "jquery": "./node_modules/jquery/dist/jquery.js"
-  },
   "browserify-shim": {
+    "./node_modules/bootstrap/js/dropdown.js": {
+      "depends": ["jquery:jQuery"]
+    },
     "./node_modules/bootstrap/js/modal.js": {
       "depends": ["jquery:jQuery"]
+    },
+    "./node_modules/pagerjs/pager.js": {
+      "exports": "pager",
+      "depends": ["jquery:$", "knockout:ko"]
     }
   }
 }

--- a/views/correction.html
+++ b/views/correction.html
@@ -7,7 +7,7 @@ Data binding context: Correction -->
   <form class="text-center" data-bind="submit: logErroneousCents.bind($data)">
     <p><input type="number" required step="0.10" class="form-control-inline form-control" data-bind="value: erroneousEuros">&nbsp;€ an Fehldrucken
     <button type="submit" class="btn btn-danger icon-money">Buchen</button></p>
-    <p>Nicht eingenommenes Pfand bitte separat in der <a href="#" data-bind="click: $root.show.bind($root, 'depositreturn')">Pfandrückgabe</a> austragen!</p>
+    <p>Nicht eingenommenes Pfand bitte separat in der <a href="#internal/depositreturn">Pfandrückgabe</a> austragen!</p>
   </form>
   <hr>
   <form class="text-center" data-bind="submit: logErroneouslyPrintedPages.bind($data)">

--- a/views/documentselection.html
+++ b/views/documentselection.html
@@ -2,6 +2,8 @@
 Data binding context: DocumentSelection. -->
 
 <div id='documents-view'>
+  <!-- two-way binding between URL and documentlist.lecture. Use a separate element so that nothing gets hidden by the lecture-less /documentselection default URL. -->
+  <div data-bind="page: { id: '?', nameParam: ko.getObservable(documentlist, 'lecture') }"></div>
   <form class='form-inline' role='form'>
     <div id='lectureSelection' class='form-group'>
       <label for='lectureName' class='sr-only'>Vorlesung</label>

--- a/views/index.html
+++ b/views/index.html
@@ -25,19 +25,19 @@
           <a class="navbar-brand" href="#">Odie</a>
         </div>
 
-        <div class="collapse navbar-collapse" id="main-nav" data-bind="visible: true" style="display: none !important;">
+        <div class="collapse navbar-collapse" id="main-nav">
           <ul class="nav navbar-nav">
-            <li data-bind="css: { active: visible === 'documentselection' }, click: visible = 'documentselection'">
-              <a href="#">
+            <li data-bind="css: { active: activePageName === 'documentselection' }">
+              <a href="#documentselection">
                 Auswahl&nbsp;<span class="badge" data-bind="text: cartSize"></span>
               </a>
             </li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
-            <li data-bind="visible: user.isAuthenticated, css: { active: visible === 'preselection' }, click: show.bind($root, 'preselection')"><a href="#">Vorauswahl</a></li>
-            <li data-bind="visible: user.isAuthenticated, css: { active: visible === 'depositreturn' }, click: show.bind($root, 'depositreturn')"><a href="#">Pfandrückgabe</a></li>
-            <li data-bind="visible: user.isAuthenticated, css: { active: visible === 'correction' }, click: show.bind($root, 'correction')"><a href="#">Abrechnungskorrektur</a></li>
-            <li data-bind="visible: !user.isAuthenticated, css: { active: visible === 'login' }, click: show.bind($root, 'login')"><a href="#">Als Fachschafter anmelden</a></li>
+            <li data-bind="visible: user.isAuthenticated, css: { active: activePageName === 'preselection' }"><a href="#internal/preselection">Vorauswahl</a></li>
+            <li data-bind="visible: user.isAuthenticated, css: { active: activePageName === 'depositreturn' }"><a href="#internal/depositreturn">Pfandrückgabe</a></li>
+            <li data-bind="visible: user.isAuthenticated, css: { active: activePageName === 'correction' }"><a href="#internal/correction">Abrechnungskorrektur</a></li>
+            <li data-bind="visible: !user.isAuthenticated, css: { active: activePageName === 'login' }"><a href="#login?successRoute=#">Als Fachschafter anmelden</a></li>
             <li data-bind="visible: user.isAuthenticated, click: logout.bind($root)"><a href="#">Abmelden</a></li>
             <li data-bind="visible: user.isAuthenticated"><a href='#' style="color: #333333 !important">Hallo,&nbsp;<span data-bind="text: user.firstName"></span></a></li>
           </ul>
@@ -54,9 +54,20 @@
     </noscript>
 
     <!-- content -->
-    <span data-bind="component: visible">
-    </span>
-
+    <div data-bind="page: { id: 'documentselection', role: 'start' }">
+      <div data-bind="component: 'documentselection'"></div>
+    </div>
+    <div data-bind="page: { id: 'login', params: ['successRoute'] }">
+      <div data-bind="component: { name: 'login', params: { successRoute: successRoute } }"></div>
+    </div>
+    <div data-bind="page: { id: 'internal', guard: ensureAuthenticated.bind($root) }">
+      <div data-bind="page: { id: '?', nameParam: 'pageID' }">
+        <div data-bind="component: pageID"></div>
+      </div>
+    </div>
+    <div data-bind="page: { id: '?' }">
+      Here be tiny fluffy dragons
+    </div>
   </div>
 
   <!-- footer -->

--- a/views/login.html
+++ b/views/login.html
@@ -1,6 +1,3 @@
-<!-- login screen template
-Data binding context: User -->
-
 <div class="row">
   <h1 class="banner">Einmal anmelden. Alle fsmi-Produkte nutzen.</h1>
   <div class="col-sm-6 col-md-4 col-md-offset-4">
@@ -10,9 +7,9 @@ Data binding context: User -->
       alt="">
       <form class="form-signin" id="login-form">
         <span class="text-warning login-error" data-bind="text: errorThrown, css: { 'icon-attention': errorThrown !== '' }"></span>
-        <input type="text" class="form-control" data-bind="value: username" placeholder="Username" required autofocus>
+        <input type="text" class="form-control" data-bind="value: user.username" placeholder="Username" required autofocus>
         <input type="password" class="form-control" data-bind="value: password" placeholder="Passwort" required>
-        <button class="btn btn-lg btn-primary btn-signin btn-block" data-bind="click: $root.login.bind($root)" type="submit">
+        <button class="btn btn-lg btn-primary btn-signin btn-block" data-bind="click: login.bind($data)" type="submit">
           Anmelden</button>
         <label class="checkbox pull-left">
           <input type="checkbox" data-bind="checked: rememberMe">


### PR DESCRIPTION
Test drive: http://kha.github.io/odie-client/dist/#documentselection/Algorithmen%20der%20Signalverarbeitung

* Provide permalinks to document selection of specific lectures
* Group other views under internal/ URL part and visually in a dropdown.
  Navigating directly to internal/ without being logged in will redirect
  you to the login page.
  * Refactor Login view model out of User class for this and make User
    a pure model

Fixes #63