### PR TITLE
Fix grey autosuggestion text getting cut off

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -68,8 +68,8 @@ body {
   vertical-align: top;
 }
 
-#nameSelection {
-  width: 500px;
+.nameSelection {
+  width: 500px !important;
 }
 
 .wrapper {

--- a/views/documentselection.html
+++ b/views/documentselection.html
@@ -14,7 +14,7 @@ Data binding context: DocumentSelection. -->
     <input
       id='nameSelection'
       type='text'
-      class='form-control-inline form-control'
+      class='form-control-inline form-control nameSelection'
       data-bind='
         value: selected ? selected.name : "",
         typeahead: {


### PR DESCRIPTION
`typeahead.js` constructs a second input element for this, and as the id gets lost on that copy, setting the width via `#`-selector won't work. The `!important` is necessary due to the stupidity of CSS precedence rules in combination with our build chain (something in bootstrap would overwrite the width, and CSS precedence is ruled via the ordering *in the CSS file*, which is concatenated automatically).