### PR TITLE
Fix unprintable loaded cart

### DIFF
--- a/js/vm/cart.js
+++ b/js/vm/cart.js
@@ -46,10 +46,6 @@ export default class Cart {
     }
   }
 
-  clone() {
-    return new Cart({name: this.name, documents: this.documents.slice()});
-  }
-
   contains(doc) {
     return this.documents.some(d => d.id === doc.id);
   }

--- a/js/vm/preselection.js
+++ b/js/vm/preselection.js
@@ -16,7 +16,9 @@ export default class Preselection {
   }
 
   openCart(cart) {
-    documentselection.cart = cart.clone();
+    documentselection.cart.reset();
+    documentselection.cart.name = cart.name;
+    documentselection.cart.documents = cart.documents.slice();
     documentselection.cart.flushToSessionStorage();
     pager.navigate('#documentselection');
   }


### PR DESCRIPTION
Don't replace DocumentSelection.cart because not all references to it
are reactive.