### PR TITLE
documentsubmission: Allow anonymous submissions

### DIFF
--- a/js/vm/documentsubmission.js
+++ b/js/vm/documentsubmission.js
@@ -11,6 +11,7 @@ export default class DocumentSubmission {
     this.selectedExaminants = [];
     this.date = null;
     this.name = null;
+    this.anonymous = false;
     this.file = null;
     this.department = 'computer science';
     this.doctype = 'oral';
@@ -62,7 +63,7 @@ export default class DocumentSubmission {
       examinants: this.selectedExaminants,
       date: this.date,
       document_type: this.doctype,
-      student_name: this.name,
+      student_name: this.anonymous ? '' : this.name,
       department: this.department,
     }));
     fd.append('file', this.file);

--- a/views/documentsubmission.html
+++ b/views/documentsubmission.html
@@ -67,7 +67,15 @@
   <div class="form-group">
     <label class="control-label col-md-3">Dein Name&nbsp;</label>
     <div class="col-md-8">
-      <input class="form-control" type="text" required="required" data-bind="value: name">
+      <input class="form-control" type="text" data-bind="value: name, disable: anonymous, attr: { 'required': !anonymous }">
+    </div>
+    <div class="col-md-3"></div>
+    <div class="col-md-8">
+      <div class="checkbox">
+        <label>
+          <input type="checkbox" data-bind="checked: anonymous"> Ohne Namen abgeben (falls du kein Pfand zurückbekommen möchtest).
+        </label>
+      </div>
     </div>
   </div>
   <div class="form-group">


### PR DESCRIPTION
Require the user to explicitly check a box saying that they don't want
their deposit back. This is in order to prevent people from simply
forgetting to enter their name.

This depends on a change in odie-server that makes student_name optional
on document submission.