### PR TITLE
Localize the document submission datepicker

### DIFF
--- a/js/ko/bootstrap-datepicker.js
+++ b/js/ko/bootstrap-datepicker.js
@@ -2,6 +2,7 @@ import $ from "jquery";
 import ko from "knockout";
 
 import "bootstrap-datepicker/js/bootstrap-datepicker";
+import "bootstrap-datepicker/js/locales/bootstrap-datepicker.de";
 
 ko.bindingHandlers.datepicker = {
   init(element, valueAccessor) {


### PR DESCRIPTION
The locale was set as a parameter for the datepicker in the view, but
the corresponding JS file was not included.