### PR TITLE
transcriptmigration: Validate documents on submission

### DIFF
--- a/js/vm/transcriptmigration.js
+++ b/js/vm/transcriptmigration.js
@@ -84,6 +84,7 @@ export default class TranscriptMigration {
       document_type: this.doctype,
       student_name: '(Migration)',
       department: 'mathematics',
+      validated: true,
     }));
     fd.append('file', this.file);
     let req = new XMLHttpRequest();


### PR DESCRIPTION
We can assume transcripts that have already been distributed in the
transcript folders are valid.

Depends on https://github.com/fsmi/odie-server/pull/138