### PR TITLE
transcriptmigration: Set req.withCredentials = true on submission.

### DIFF
--- a/js/vm/transcriptmigration.js
+++ b/js/vm/transcriptmigration.js
@@ -96,6 +96,7 @@ export default class TranscriptMigration {
     }));
     fd.append('file', this.file);
     let req = new XMLHttpRequest();
+    req.withCredentials = true;
     req.open('POST', api.baseUrl + 'documents_migration');
     req.onerror = (e) => {
       this.status = 'error';


### PR DESCRIPTION
For some reason, leaving this out causes my browser not to send cookies
to odie-server when testing locally.