### PR TITLE
transcriptmigration: Always use canonical lecture name in input field.

### DIFF
--- a/views/transcriptmigration.html
+++ b/views/transcriptmigration.html
@@ -16,7 +16,7 @@
             <select class="form-control" id="transcript-migration-lectures" multiple="true" data-bind="tagsinput: {
                   confirmKeys: [13],
                   items: ko.getObservable($data, 'selectedLectures'),
-                  itemValue: 'name',
+                  itemValue: (item) => item.obj.name,
                   freeInput: true,
                   typeaheadjs: [null, lecturesTypeaheadDataset],
                 }"></select>


### PR DESCRIPTION
e880780 would enter the lecture's alias in the input field instead,
theoretically allowing a user to enter a lecture multiple times using
multiple aliases.