### PR TITLE
transcriptmigration: Keep a list of recent lectures/examinants

### DIFF
--- a/js/vm/transcriptmigration.js
+++ b/js/vm/transcriptmigration.js
@@ -15,6 +15,8 @@ export default class TranscriptMigration {
   constructor() {
     this.selectedLectures = [];
     this.selectedExaminants = [];
+    this.recentLectures = [];
+    this.recentExaminants = [];
     this.similar = [];
     this.date = '';
     this.doctype = 'oral';
@@ -129,6 +131,13 @@ export default class TranscriptMigration {
             this.status = 'success';
             this.errorlabel = '';
             this.submissionEnabled = true;
+
+            this.recentLectures.removeAll(this.selectedLectures);
+            this.recentLectures = this.selectedLectures.concat(this.recentLectures).slice(0, 5);
+
+            this.recentExaminants.removeAll(this.selectedExaminants);
+            this.recentExaminants = this.selectedExaminants.concat(this.recentExaminants).slice(0, 5);
+
             // Clear inputs. Note: The file input field cannot be cleared since we can obviously not write its value.
             this.selectedLectures = [];
             this.selectedExaminants = [];

--- a/views/transcriptmigration.html
+++ b/views/transcriptmigration.html
@@ -20,6 +20,14 @@
                   typeaheadjs: [null, lecturesTypeaheadDataset],
                 }"></select>
           </div>
+          <div class="col-md-3"></div>
+          <div class="col-md-8">
+            <span data-bind="visible: recentLectures.length > 0">Zuletzt:</span>
+            <!-- ko foreach: recentLectures -->
+              <a href="#" data-bind="text: $data, click: function(data, event) { $('#transcript-migration-lectures').tagsinput('add', $data); }"></a>
+              <span data-bind="visible: $index() < $parent.recentLectures.length - 1">&middot;</span>
+            <!-- /ko -->
+          </div>
         </div>
         <div class="form-group">
           <label class="control-label col-md-3">Prüfer&nbsp;</label>
@@ -30,6 +38,14 @@
                   freeInput: true,
                   typeaheadjs: [null, examinantsTypeaheadDataset],
                 }"></select>
+          </div>
+          <div class="col-md-3"></div>
+          <div class="col-md-8">
+            <span data-bind="visible: recentExaminants.length > 0">Zuletzt:</span>
+            <!-- ko foreach: recentExaminants -->
+              <a href="#" data-bind="text: $data, click: function(data, event) { $('#transcript-migration-examinants').tagsinput('add', $data); }"></a>
+              <span data-bind="visible: $index() < $parent.recentExaminants.length - 1">&middot;</span>
+            <!-- /ko -->
           </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION
The 5 most recent lectures and examinants are provided in a list and
added on click. This should speed up the migration process as there are
many transcripts that share examinants or lectures.

NB: I use `$('#transcript-migration-lectures').tagsinput('add', $data);`
instead of modifying `recentLectures` directly because tagsinput does
not always correctly update this way. Also, I get the nice "already
exists" animation for free.