### PR TITLE
documentsubmission: Allow entering lectures by alias

### DIFF
--- a/js/vm/documentsubmission.js
+++ b/js/vm/documentsubmission.js
@@ -1,10 +1,15 @@
 /*global FormData XMLHttpRequest*/
 import ko from "knockout";
+import flatten from "lodash/array/flatten";
 
 import api from "../api";
 import makeSource from "../typeaheadsource";
 import store from "../store";
 import user from "./user";
+
+function wrapLectureAlias(alias, canonical) {
+  return {alias, canonical}
+}
 
 export default class DocumentSubmission {
   constructor() {
@@ -23,11 +28,24 @@ export default class DocumentSubmission {
     ko.track(this);
   }
 
-  typeaheadDataset(type) {
+  get examinantsTypeaheadDataset() {
     return {
-      source: makeSource(store[type].filter(x => x.validated || user.isAuthenticated).map(e => e.name)),
+      source: makeSource(store.examinants.filter(x => x.validated || user.isAuthenticated).map(e => e.name)),
       templates: {
         suggestion: l => `<a href="#" onclick="return false;">${l}</a>`,
+      },
+    };
+  }
+
+  get lecturesTypeaheadDataset() {
+    return {
+      source: makeSource(flatten(store.lectures.filter(x => x.validated || user.isAuthenticated).map(l =>
+                [l.name].concat(l.aliases).map(alias => wrapLectureAlias(alias, l.name))
+              )), 'alias'),
+      display: 'canonical',
+      valueKey: 'canonical', /* needed by bootstrap-tagsinput */
+      templates: {
+        suggestion: x => `<a href="#" onclick="return false;">${x.alias}${x.alias === x.canonical ? "" : ` <span class="full-name">${x.canonical}</span>`}</a>`,
       },
     };
   }

--- a/views/documentsubmission.html
+++ b/views/documentsubmission.html
@@ -20,7 +20,7 @@
             confirmKeys: [13],
             items: ko.getObservable($data, 'selectedLectures'),
             freeInput: true,
-            typeaheadjs: [null, typeaheadDataset('lectures')],
+            typeaheadjs: [null, lecturesTypeaheadDataset],
           }"></select>
       <span class="help-block">
         Vorlesung nicht in der Vorschlagsliste? Passt schon, einfach Namen eingeben &amp; Enter drücken.
@@ -42,7 +42,7 @@
             confirmKeys: [13],
             items: ko.getObservable($data, 'selectedExaminants'),
             freeInput: true,
-            typeaheadjs: [null, typeaheadDataset('examinants')],
+            typeaheadjs: [null, examinantsTypeaheadDataset],
           }"></select>
       <span class="help-block">
         Prüfer nicht in der Vorschlagsliste? Passt schon, einfach Namen eingeben &amp; Enter drücken.


### PR DESCRIPTION
This is basically e9f897f + 96d61ce + e880780 ported from
transcriptmigration to documentsubmission, but without all the fixups
in between.