### PR TITLE
views/documentselection: Make document type count a label.

### DIFF
--- a/views/documentlist.html
+++ b/views/documentlist.html
@@ -15,7 +15,7 @@
       <td class="td-compact">#</td>
       <td colspan="2" class="td-compact" data-bind="foreach: documentTypes">
         <div data-bind="visible: totalCount">
-          <input type="checkbox" data-bind="checked: selected"><span data-bind="attr: {title: title}, html: icon"></span> <span data-bind="text: count + '/' + (totalCount === undefined ? '' : totalCount)"></span>
+          <input type="checkbox" data-bind="checked: selected, attr: {'id': 'showdoctype-' + name}"><label data-bind="attr: {'for': 'showdoctype-' + name}" style="font-weight: inherit;"><span data-bind="attr: {title: title}, html: icon"></span> <span data-bind="text: count + '/' + (totalCount === undefined ? '' : totalCount)"></span>
         </div>
       </td>
       <td>Vorlesungen</td>


### PR DESCRIPTION
So that you don't have to hit the tiny, tiny checkbox when
selecting/deselecting document types.

Using "font-weight: inherit" style attribute because labels are normally
bold, but table headers are not.