### PR TITLE
Removed private erroneous pages correction

### DIFF
--- a/js/vm/correction.js
+++ b/js/vm/correction.js
@@ -10,7 +10,6 @@ import user from "./user";
 // Handles accounting corrections - erroneously printed pages, etc.
 export default class Correction {
   constructor() {
-    this.erroneousPages = 0;
     this.erroneousCents = 0;
     this.donationCents = 0;
     // Registering deposit without printing is done by submitting a print job with
@@ -38,11 +37,6 @@ export default class Correction {
   logErroneousCents() {
     this._logErroneous(this.erroneousCents);
     this.erroneousCents = 0;
-  }
-
-  logErroneouslyPrintedPages() {
-    this._logErroneous(this.erroneousPages * store.config.PRICE_PER_PAGE);
-    this.erroneousPages = 0;
   }
 
   makeDeposit() {

--- a/views/correction.html
+++ b/views/correction.html
@@ -11,11 +11,6 @@ Data binding context: Correction -->
     <p>Nicht eingenommenes Pfand bitte separat in der <a href="#internal/depositreturn">Pfandrückgabe</a> austragen!</p>
   </form>
   <hr>
-  <form class="text-center" data-bind="submit: logErroneouslyPrintedPages.bind($data)">
-    <input type="number" required min="1" class="number-input form-control-inline form-control" data-bind="value: erroneousPages"> Seiten an <strong>privaten</strong> Fehldrucken
-    <button type="submit" class="btn btn-danger icon-money">Buchen</button>
-  </form>
-  <hr>
   <h3 class="heading">Protokollpfand nachträglich eintragen:</h3>
 
   <div class="text-center">


### PR DESCRIPTION
This PR removes the section for logging erroneous private prints from the correction page as it is no longer needed.