### PR TITLE
Security: Fix XSS in typeahead suggestions

### DIFF
--- a/js/vm/documentselection.js
+++ b/js/vm/documentselection.js
@@ -54,14 +54,40 @@ class DocumentSelection {
 
   get typeaheadDatasets() {
     let make = (name, items) => {
+      let headerContainer = document.createElement('div');
+      // like `<h4 class="tt-header">${name}</h4><div class="divider"></div>`, but without XSS
+      {
+        let h4 = document.createElement('h4');
+        h4.className = 'tt-header';
+        h4.textContent = name;
+        let divider = document.createElement('div');
+        divider.className = 'divider';
+        headerContainer.append(h4, divider);
+      }
+
+      let suggestionFunction = function(x) {
+        // like `<a href="#" onclick="return false;">${x.name}${x.name === x.obj.name ? "" : ` <span class="full-name">${x.obj.name}</span>`}</a>`,
+        // but without XSS
+        let a = document.createElement('a');
+        a.setAttribute('onclick', 'return false;');
+        a.href = '#';
+        a.textContent = x.name;
+        if (x.name !== x.obj.name) {
+          let span = document.createElement('span');
+          span.className = 'full-name';
+          span.textContent = x.obj.name;
+          a.append(' ', span);
+        }
+        return a.outerHTML;
+      }
+
       return {
         source: makeSource(items.filter(x => x.obj.validated || user.isAuthenticated), 'name'),
-        displayKey: "name",
+        displayKey: 'name',
         limit: 20,
         templates: {
-          header:
-            `<h4 class="tt-header">${name}</h4><div class="divider"></div>`,
-          suggestion: x => `<a href="#" onclick="return false;">${x.name}${x.name === x.obj.name ? "" : ` <span class="full-name">${x.obj.name}</span>`}</a>`,
+          header: headerContainer.innerHTML,
+          suggestion: suggestionFunction,
         },
       };
     };

--- a/js/vm/documentsubmission.js
+++ b/js/vm/documentsubmission.js
@@ -42,7 +42,14 @@ export default class DocumentSubmission {
     return {
       source: makeSource(store.examinants.filter(x => x.validated || user.isAuthenticated).map(e => e.name)),
       templates: {
-        suggestion: l => `<a href="#" onclick="return false;">${l}</a>`,
+        suggestion: l => {
+          // like ``<a href="#" onclick="return false;">${l}</a>``, but without XSS
+          let a = document.createElement('a');
+          a.setAttribute('onclick', 'return false;');
+          a.href = '#';
+          a.textContent = l;
+          return a.outerHTML;
+        },
       },
     };
   }
@@ -55,7 +62,21 @@ export default class DocumentSubmission {
       display: 'canonical',
       valueKey: 'canonical', /* needed by bootstrap-tagsinput */
       templates: {
-        suggestion: x => `<a href="#" onclick="return false;">${x.alias}${x.alias === x.canonical ? "" : ` <span class="full-name">${x.canonical}</span>`}</a>`,
+        suggestion: x => {
+          // like `<a href="#" onclick="return false;">${x.alias}${x.alias === x.canonical ? "" : ` <span class="full-name">${x.canonical}</span>`}</a>`,
+          // but without XSS
+          let a = document.createElement('a');
+          a.setAttribute('onclick', 'return false;');
+          a.href = '#';
+          a.textContent = x.alias;
+          if (x.alias !== x.canonical) {
+            let span = document.createElement('span');
+            span.className = 'full-name';
+            span.textContent = x.canonical;
+            a.append(' ', span);
+          }
+          return a.outerHTML;
+        }
       },
     };
   }


### PR DESCRIPTION
Several places didn't escape user input in typeahead suggestions
(lecture and examinant names), allowing XSS.

This was exploitable by unauthenticated users: They could upload a
document with a new lecture/examinant name, the contained &lt;script&gt; would
then be run when an authenticated user (because the document has not yet
been validated) finds the document in autocompletion.